### PR TITLE
Add accounting v1 and v2 links

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -29,21 +29,23 @@ $pages = [
         ['Ultrasound Billing (example)', 'ultrasound_billing.php?visit_id=1'],
         ['Doctor Incentives', 'doctor_incentives.php'],
     ],
-    'Accounting & Finance' => [
+    'Accounting v1' => [
         ['Accounting Dashboard', 'Accounting/accounting_dashboard.php'],
         ['Profit & Loss Statement', 'Accounting/profit_loss_statement.php'],
         ['Balance Sheet', 'Accounting/balance_sheet.php'],
         ['Trial Balance', 'Accounting/trial_balance.php'],
         ['Cash Flow Statement', 'Accounting/cash_flow_statement.php'],
         ['Bank Statement Upload', 'Accounting/bank_statement_upload.php'],
-        ['Chart of Accounts', 'Accounting/chart_of_accounts.php'],
-        ['Journal Entries', 'Accounting/journal_entries.php'],
+        ['Setup Accounting', 'Accounting/setup_accounting.php'],
+        ['Main Accounting', 'Accounting/accounting.php'],
+    ],
+    'Accounting v2' => [
+        ['Accounting Reports', 'AccountingGPT/accounting_reports.php'],
+        ['Bank Statement Upload', 'AccountingGPT/bank_statement_upload.php'],
     ],
     'Reports & System' => [
         ['Summary Report', 'summary.php'],
         ['System Log', 'system_log.php'],
-        ['Accounting Reports', 'AccountingGPT/accounting_reports.php'],
-        ['Bank Statement Upload', 'AccountingGPT/bank_statement_upload.php'],
     ],
 ];
 ?>


### PR DESCRIPTION
Add separate 'Accounting v1' and 'Accounting v2' sections to the admin page for clear access to both accounting systems.

---
<a href="https://cursor.com/background-agent?bcId=bc-7b0b8c90-d72a-4e56-bbe7-dc59abc7991c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7b0b8c90-d72a-4e56-bbe7-dc59abc7991c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

