### PR TITLE
Fix homepage visit table updates

### DIFF
--- a/includes/db.php
+++ b/includes/db.php
@@ -38,12 +38,15 @@ try {
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         patient_id INTEGER NOT NULL,
         doctor_id INTEGER,
-        visit_date DATE NOT NULL,
+        visit_date DATE NOT NULL DEFAULT (DATE('now')),
         reason TEXT,
         status TEXT DEFAULT 'pending',
         created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
         FOREIGN KEY (patient_id) REFERENCES patients(id)
     )");
+    
+    // Fix any existing visits that might have NULL visit_date
+    $pdo->exec("UPDATE visits SET visit_date = DATE(created_at) WHERE visit_date IS NULL OR visit_date = ''");
     
     // Create doctors table if it doesn't exist
     $pdo->exec("CREATE TABLE IF NOT EXISTS doctors (

--- a/includes/patient.php
+++ b/includes/patient.php
@@ -83,10 +83,14 @@ function register_visit($pdo, $data) {
             throw new Exception("Missing required field: $field");
         }
     }
-    $stmt = $pdo->prepare("INSERT INTO visits (patient_id, doctor_id, reason, referred_by) VALUES (?, ?, ?, ?)");
+    // Set visit_date to current date if not provided
+    $visit_date = isset($data['visit_date']) ? $data['visit_date'] : date('Y-m-d');
+    
+    $stmt = $pdo->prepare("INSERT INTO visits (patient_id, doctor_id, visit_date, reason, referred_by) VALUES (?, ?, ?, ?, ?)");
     $stmt->execute([
         $data['patient_id'],
         $data['doctor_id'],
+        $visit_date,
         $data['reason'],
         isset($data['referred_by']) ? $data['referred_by'] : null
     ]);

--- a/index.php
+++ b/index.php
@@ -128,7 +128,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 }
 
 // Fetch today's visits for summary table
-$today_visits = $pdo->query("SELECT v.id AS visit_id, v.visit_date, v.reason, p.id AS patient_id, p.full_name, p.dob, p.gender, p.contact_number, p.address, p.lead_source, d.name AS doctor_name, d.specialty FROM visits v JOIN patients p ON v.patient_id = p.id JOIN doctors d ON v.doctor_id = d.id WHERE DATE(v.visit_date) = CURDATE() ORDER BY v.visit_date DESC")->fetchAll();
+$today_visits = $pdo->query("SELECT v.id AS visit_id, v.visit_date, v.reason, p.id AS patient_id, p.full_name, p.dob, p.gender, p.contact_number, p.address, p.lead_source, d.name AS doctor_name, d.specialty FROM visits v JOIN patients p ON v.patient_id = p.id JOIN doctors d ON v.doctor_id = d.id WHERE DATE(v.visit_date) = DATE('now') ORDER BY v.visit_date DESC")->fetchAll();
 
 // Fetch all patients who have ever visited, with last visit date and total visits
 $all_visited_patients = $pdo->query("SELECT p.id, p.full_name, MAX(v.visit_date) AS last_visit, COUNT(v.id) AS visit_count FROM patients p JOIN visits v ON p.id = v.patient_id GROUP BY p.id, p.full_name ORDER BY last_visit DESC")->fetchAll();


### PR DESCRIPTION
Fix visit tables not updating due to missing `visit_date` on insertion and MySQL-specific date functions in SQLite queries.

---
<a href="https://cursor.com/background-agent?bcId=bc-30297561-81bd-4e28-baf9-bfa3f66dd495">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-30297561-81bd-4e28-baf9-bfa3f66dd495">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

