### PR TITLE
Fix database access denied error

### DIFF
--- a/includes/db.php
+++ b/includes/db.php
@@ -2,7 +2,7 @@
 // includes/db.php - Database connection
 // Supports SQLite (default) and MySQL. Edit placeholders below for MySQL.
 
-$DB_DRIVER = getenv('DB_DRIVER') ?: 'mysql'; // 'sqlite' or 'mysql'
+$DB_DRIVER = getenv('DB_DRIVER') ?: 'sqlite'; // 'sqlite' or 'mysql'
 $DB_HOST = getenv('DB_HOST') ?: 'localhost';
 $DB_NAME = getenv('DB_NAME') ?: 'iwqgalpa_register';
 $DB_USER = getenv('DB_USER') ?: 'iwqgalpa_admin';


### PR DESCRIPTION
Switch default database driver to SQLite to resolve PDO "Access denied" error due to missing MySQL.

The environment lacked a MySQL installation, causing a `PDOException` with "Access denied" when attempting to connect using the default `mysql` driver. Since SQLite was already supported by the application and an SQLite database file was present, changing the default driver to `sqlite` allows the application to connect successfully without requiring MySQL server setup.

---
<a href="https://cursor.com/background-agent?bcId=bc-b398242e-0022-49d9-b438-f63aeeed2382">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b398242e-0022-49d9-b438-f63aeeed2382">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

